### PR TITLE
Fix #1: Use member inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Fable.DateFunctions 
+# Fable.DateFunctions
 
-Fable binding for popular [date-fns](https://date-fns.org/), a library for date manipulation. This binding implements the imports as 120+ extension methods for `DateTime` instances (and a couple of static members for `DateTime`). 32 Languages are supported for formatting dates, see [live demo](https://zaid-ajaj.github.io/Fable.DateFunctions/).
+Fable binding for popular [date-fns](https://date-fns.org/), a library for date manipulation. This binding implements the imports as 120+ extension methods for `DateTime` instances (and a couple of static member inlines for `DateTime`). 32 Languages are supported for formatting dates, see [live demo](https://zaid-ajaj.github.io/Fable.DateFunctions/).
 
-## Installation 
+## Installation
 Install the binding from Nuget
 ```
-paket add Fable.DateFunctions --project path/to/Proj.fsproj 
+paket add Fable.DateFunctions --project path/to/Proj.fsproj
 ```
 Install the actual Javascript library from npm
 ```
@@ -13,7 +13,7 @@ npm install --save date-fns
 ```
 Now from your F# code
 ```fs
-open Fable.DateFunctions 
+open Fable.DateFunctions
 
 let now = DateTime.Now
 now.SubtractDays(1).IsInThePast() // true
@@ -30,7 +30,7 @@ now.SubtractDays(1).IsInThePast() // true
 1. Start Fable server and Webpack dev server: `./build.sh Watch`
 2. In your browser, open: http://localhost:8080/
 
-Any modification you do to the F# code will be reflected in the web page after 
+Any modification you do to the F# code will be reflected in the web page after
 saving.
 
 

--- a/app/View.fs
+++ b/app/View.fs
@@ -12,29 +12,29 @@ open Fable.Helpers.React.Props
 open Fable.DateFunctions
 open Fable.Core
 open Fable.Core.JsInterop
-let now = DateTime.Now 
+let now = DateTime.Now
 let tomorrow = now.AddDays(1)
 let yesterday = now.SubtractDays(1)
 
 let formatOptions = createEmpty<IDistanceInWordsOptions>
-formatOptions.includeSeconds <- false 
-formatOptions.addSuffix <- true 
+formatOptions.includeSeconds <- false
+formatOptions.addSuffix <- true
 formatOptions.locale <- DateTime.Locales.Dutch
 
 let sometimeAgo = now.SubtractMonths(1).SubtractDays(4)
 let formatted = sometimeAgo.DistanceInWordsToNow(formatOptions)
 
-let introduction = 
-    div [ ]  
+let introduction =
+    div [ ]
         [ h1 [ Style [ FontSize 30 ] ] [ a [ Href "https://github.com/Zaid-Ajaj/Fable.DateFunctions" ] [ str "Fable.DateFunctions"  ]  ]
-          p  [ ] [ span [ ] [ str "Fable binding for ";  a [ Href "https://date-fns.org/" ] [ str "date-fns" ]; str " with 120+ functions for working with dates, implemented as extension methods for DateTime (some methods are static members for DateTime)" ] ]
+          p  [ ] [ span [ ] [ str "Fable binding for ";  a [ Href "https://date-fns.org/" ] [ str "date-fns" ]; str " with 120+ functions for working with dates, implemented as extension methods for DateTime (some methods are static member inlines for DateTime)" ] ]
           hr [ ]
           h1 [ Style [ FontSize 30 ] ] [ str "Examples and configurations" ]
           Common.highlight """let now = DateTime.Now
 let yesterday = now.SubtractDays(1)
 let tomorrow = now.AddDays(1)"""
-          Common.highlight (sprintf "now.IsToday() // => %A" (now.IsToday())) 
-          Common.highlight (sprintf "now.DistanceInWords(tomorrow) // => %A" (now.DistanceInWords(tomorrow))) 
+          Common.highlight (sprintf "now.IsToday() // => %A" (now.IsToday()))
+          Common.highlight (sprintf "now.DistanceInWords(tomorrow) // => %A" (now.DistanceInWords(tomorrow)))
           Common.highlight (sprintf "now.IsTomorrow() // => %A" (now.IsTomorrow()))
           Common.highlight (sprintf "now.IsInTheSameDayAs(tomorrow) // => %A" (now.IsInTheSameDayAs(tomorrow)))
           Common.highlight (sprintf "tomorrow.IsInTheSameDayAs(tomorrow) // => %A" (tomorrow.IsInTheSameDayAs(tomorrow)))
@@ -44,20 +44,20 @@ let tomorrow = now.AddDays(1)"""
           Common.highlight (sprintf "yesterday.EndOfDay() // => %A" (yesterday.EndOfDay()))
           Common.highlight (sprintf "now.StartOfDay() // => %A" (now.StartOfDay()))
           Common.highlight (sprintf "now.IsInSameMinuteAs(now.AddSeconds(5.0)) // => %A" (now.IsInSameMinuteAs(now.AddSeconds(5.0))))
-          Common.highlight (sprintf "now.IsBetween(yesterday, tomorrow) ==> %A" (now.IsBetween(yesterday, tomorrow))) 
-          Common.highlight (sprintf "now.SubtractDays(1).IsInThePast()  ==> %A" (now.SubtractDays(1).IsInThePast())) 
+          Common.highlight (sprintf "now.IsBetween(yesterday, tomorrow) ==> %A" (now.IsBetween(yesterday, tomorrow)))
+          Common.highlight (sprintf "now.SubtractDays(1).IsInThePast()  ==> %A" (now.SubtractDays(1).IsInThePast()))
           h1 [ Style [ FontSize 30 ] ] [ str "Locales Support (32 languages)" ]
           p [ ] [ span [ ] [ str "See "; a [ Href "https://date-fns.org/v1.29.0/docs/format" ] [ str "https://date-fns.org/v1.29.0/docs/format" ]; str " for the full documentation on formatting strings" ]  ]
-          Common.highlight (sprintf "now.Format(\"Do MMMM YYYY\", DateTime.Locales.Russian) ==> %A" (now.Format("Do MMMM YYYY", DateTime.Locales.Dutch))) 
-          Common.highlight (sprintf "now.Format(\"Do MMMM YYYY\", DateTime.Locales.Spanish) ==> %A" (now.Format("Do MMMM YYYY", DateTime.Locales.Spanish))) 
-          Common.highlight (sprintf "now.Format(\"Do MMMM YYYY\", DateTime.Locales.French) ==> %A" (now.Format("Do MMMM YYYY", DateTime.Locales.French))) 
-          Common.highlight (sprintf "now.Format(\"Do MMMM YYYY\", DateTime.Locales.Japanese) ==> %A" (now.Format("Do MMMM YYYY", DateTime.Locales.Japanese))) 
-          Common.highlight (sprintf "now.Format(\"Do MMMM YYYY\", DateTime.Locales.Russian) ==> %A" (now.Format("Do MMMM YYYY", DateTime.Locales.Russian))) 
+          Common.highlight (sprintf "now.Format(\"Do MMMM YYYY\", DateTime.Locales.Russian) ==> %A" (now.Format("Do MMMM YYYY", DateTime.Locales.Dutch)))
+          Common.highlight (sprintf "now.Format(\"Do MMMM YYYY\", DateTime.Locales.Spanish) ==> %A" (now.Format("Do MMMM YYYY", DateTime.Locales.Spanish)))
+          Common.highlight (sprintf "now.Format(\"Do MMMM YYYY\", DateTime.Locales.French) ==> %A" (now.Format("Do MMMM YYYY", DateTime.Locales.French)))
+          Common.highlight (sprintf "now.Format(\"Do MMMM YYYY\", DateTime.Locales.Japanese) ==> %A" (now.Format("Do MMMM YYYY", DateTime.Locales.Japanese)))
+          Common.highlight (sprintf "now.Format(\"Do MMMM YYYY\", DateTime.Locales.Russian) ==> %A" (now.Format("Do MMMM YYYY", DateTime.Locales.Russian)))
           p [ ] [ str "Distance in words" ]
           Common.highlight (sprintf """let formatOptions = createEmpty<IDistanceInWordsOptions>
-formatOptions.includeSeconds <- false 
-formatOptions.addSuffix <- true 
-formatOptions.locale <- DateTime.Locales.Dutch  
+formatOptions.includeSeconds <- false
+formatOptions.addSuffix <- true
+formatOptions.locale <- DateTime.Locales.Dutch
 
 DateTime.Now.SubtractMonths(1).DistanceInWordsToNow(formatOptions) => // "%s" """ formatted)
           ]
@@ -65,5 +65,5 @@ DateTime.Now.SubtractMonths(1).DistanceInWordsToNow(formatOptions) => // "%s" ""
 
 let spacing = Props.Style [ Props.Padding 20 ]
 
-let render (state: State) dispatch = 
+let render (state: State) dispatch =
     introduction

--- a/src/CommonHelpers.fs
+++ b/src/CommonHelpers.fs
@@ -7,88 +7,87 @@ open Fable.Import
 
 
 [<AutoOpen>]
-module CommonHelpers = 
+module CommonHelpers =
 
     type DateTime with
         /// Returns an index of the closest date from the array comparing to the given date.
-        member date.ClosestIndexTo(otherDates: DateTime []) : int = ExternalDateFns.closestIndexTo date otherDates
+        member inline date.ClosestIndexTo(otherDates: DateTime []) : int = ExternalDateFns.closestIndexTo date otherDates
         /// Returns a date from the array closest to the given date.
-        member date.ClosestTo(otherDates: DateTime []) : DateTime = ExternalDateFns.closestTo date otherDates
+        member inline date.ClosestTo(otherDates: DateTime []) : DateTime = ExternalDateFns.closestTo date otherDates
         /// Compare the two dates and return 1 if the first date is after the second, -1 if the first date is before the second or 0 if dates are equal.
-        member date.CompareAsc(other: DateTime) : int = ExternalDateFns.compareAsc date other
+        member inline date.CompareAsc(other: DateTime) : int = ExternalDateFns.compareAsc date other
         /// Compare the two dates and return -1 if the first date is after the second, 1 if the first date is before the second or 0 if dates are equal.
-        member date.CompareDesc(other: DateTime) : int = ExternalDateFns.compareDesc date other 
+        member inline date.CompareDesc(other: DateTime) : int = ExternalDateFns.compareDesc date other
         /// Return the distance between the given dates in words.
-        member date.DistanceInWords(other: DateTime) : string = ExternalDateFns.distanceInWords date other (obj())
+        member inline date.DistanceInWords(other: DateTime) : string = ExternalDateFns.distanceInWords date other (obj())
         /// Return the distance between the given dates in words with given options
-        member date.DistanceInWords(other : DateTime, opts: IDistanceInWordsOptions) : string = ExternalDateFns.distanceInWords date other opts
+        member inline date.DistanceInWords(other : DateTime, opts: IDistanceInWordsOptions) : string = ExternalDateFns.distanceInWords date other opts
         /// Return the distance between the given dates in words, using strict units. This is like distanceInWords, but does not use helpers like 'almost', 'over', 'less than' and the like.
-        member date.DistanceInWordsStrict(other: DateTime, opts: IDistanceInWordsStrictOptions) : string = ExternalDateFns.dictanceInWordsStrict date other opts
+        member inline date.DistanceInWordsStrict(other: DateTime, opts: IDistanceInWordsStrictOptions) : string = ExternalDateFns.dictanceInWordsStrict date other opts
         /// Returns the distance between the given date and now in words.
-        member otherDate.DistanceInWordsToNow(opts: IDistanceInWordsOptions) : string = ExternalDateFns.distanceInWordsToNow otherDate opts
+        member inline otherDate.DistanceInWordsToNow(opts: IDistanceInWordsOptions) : string = ExternalDateFns.distanceInWordsToNow otherDate opts
         /// Returns the formatted date string in the given default format:
         /// YYYY-MM-DDTHH:mm:ss.SSSZ.
-        member date.Format() : string = ExternalDateFns.format date
+        member inline date.Format() : string = ExternalDateFns.format date
         /// Return the formatted date string in the given format. See https://date-fns.org/v1.29.0/docs/format for docs
-        member date.Format(format: string) : string = ExternalDateFns.formatWithStr date format
+        member inline date.Format(format: string) : string = ExternalDateFns.formatWithStr date format
         /// Return the formatted date string in the given format and locale. See https://date-fns.org/v1.29.0/docs/format for docs
-        member date.Format(format: string, locale: ILocale) : string =
-            let formatOptions = createEmpty<IDateFormatOptions> 
-            formatOptions.locale <- locale  
+        member inline date.Format(format: string, locale: ILocale) : string =
+            let formatOptions = createEmpty<IDateFormatOptions>
+            formatOptions.locale <- locale
             ExternalDateFns.formatWithStrAndOptions date format formatOptions
 
         /// Returns whether the first date is after the second one.
-        member fstDate.IsAfter(sndDate: DateTime) : bool = ExternalDateFns.isAfter fstDate sndDate
+        member inline fstDate.IsAfter(sndDate: DateTime) : bool = ExternalDateFns.isAfter fstDate sndDate
         /// Returns whether the second date is before the first one.
-        member fstDate.IsBefore(sndDate: DateTime) : bool = ExternalDateFns.isBefore fstDate sndDate
+        member inline fstDate.IsBefore(sndDate: DateTime) : bool = ExternalDateFns.isBefore fstDate sndDate
         /// Returns whether the given argument is an instance of DateTime.
-        member date.IsDate() : bool = ExternalDateFns.isDate date
+        member inline date.IsDate() : bool = ExternalDateFns.isDate date
         /// Returns whether the given dates are equal.
-        member date.AreEqual(otherDate: DateTime) : bool = ExternalDateFns.isEqual date otherDate
+        member inline date.AreEqual(otherDate: DateTime) : bool = ExternalDateFns.isEqual date otherDate
         /// Returns whether the given date is in the future.
-        member date.IsInTheFuture() : bool = ExternalDateFns.isFuture date
+        member inline date.IsInTheFuture() : bool = ExternalDateFns.isFuture date
          /// Returns whether the given date is in the past.
-        member date.IsInThePast() : bool = ExternalDateFns.isPast date
+        member inline date.IsInThePast() : bool = ExternalDateFns.isPast date
         /// Returns false if argument is Invalid Date and true otherwise. Invalid Date is a Date, whose time value is NaN.
-        member date.IsValid() : bool = ExternalDateFns.isValid date
+        member inline date.IsValid() : bool = ExternalDateFns.isValid date
         /// Return the latest of the given dates.
-        static member Max([<ParamArray>] dates: DateTime[]) : DateTime = ExternalDateFns.max dates
+        static member inline Max([<ParamArray>] dates: DateTime[]) : DateTime = ExternalDateFns.max dates
         /// Return the earliest of the given dates.
-        static member Min([<ParamArray>] dates: DateTime[]) : DateTime = ExternalDateFns.min dates
+        static member inline Min([<ParamArray>] dates: DateTime[]) : DateTime = ExternalDateFns.min dates
         /// Convert the given argument to an instance of Date.
         /// If the argument is an instance of Date, the function returns its clone.
         /// If the argument is a number, it is treated as a timestamp.
         /// If an argument is a string, the function tries to parse it. Function accepts complete ISO 8601 formats as well as partial implementations. ISO 8601: http://en.wikipedia.org/wiki/ISO_8601
         /// If all above fails, the function passes the given argument to Date constructor.
-        static member Parse(date: string) : DateTime = ExternalDateFns.parse date
+        static member inline Parse(date: string) : DateTime = ExternalDateFns.parse date
         /// Convert the given argument to an instance of Date.
         /// If the argument is an instance of Date, the function returns its clone.
         /// If the argument is a number, it is treated as a timestamp.
         /// If an argument is a string, the function tries to parse it. Function accepts complete ISO 8601 formats as well as partial implementations. ISO 8601: http://en.wikipedia.org/wiki/ISO_8601
         /// If all above fails, the function passes the given argument to Date constructor.
-        static member Parse(date: int) : DateTime = ExternalDateFns.parse date
+        static member inline Parse(date: int) : DateTime = ExternalDateFns.parse date
         /// Convert the given argument to an instance of Date.
         /// If the argument is an instance of Date, the function returns its clone.
         /// If the argument is a number, it is treated as a timestamp.
         /// If an argument is a string, the function tries to parse it. Function accepts complete ISO 8601 formats as well as partial implementations. ISO 8601: http://en.wikipedia.org/wiki/ISO_8601
         /// If all above fails, the function passes the given argument to Date constructor.
-        static member Parse(date: DateTime) : DateTime = ExternalDateFns.parse date
+        static member inline Parse(date: DateTime) : DateTime = ExternalDateFns.parse date
         /// Convert the given argument to an instance of Date.
         /// If the argument is an instance of Date, the function returns its clone.
         /// If the argument is a number, it is treated as a timestamp.
         /// If an argument is a string, the function tries to parse it. Function accepts complete ISO 8601 formats as well as partial implementations. ISO 8601: http://en.wikipedia.org/wiki/ISO_8601
         /// If all above fails, the function passes the given argument to Date constructor.
-        static member Parse(date: string, opts: ParseOpts) : DateTime = ExternalDateFns.parseWithOpts date opts
+        static member inline Parse(date: string, opts: ParseOpts) : DateTime = ExternalDateFns.parseWithOpts date opts
         /// Convert the given argument to an instance of Date.
         /// If the argument is an instance of Date, the function returns its clone.
         /// If the argument is a number, it is treated as a timestamp.
         /// If an argument is a string, the function tries to parse it. Function accepts complete ISO 8601 formats as well as partial implementations. ISO 8601: http://en.wikipedia.org/wiki/ISO_8601
         /// If all above fails, the function passes the given argument to Date constructor.
-        static member Parse(date: DateTime, opts: ParseOpts) : DateTime = ExternalDateFns.parseWithOpts date opts
+        static member inline Parse(date: DateTime, opts: ParseOpts) : DateTime = ExternalDateFns.parseWithOpts date opts
         /// Convert the given argument to an instance of Date.
         /// If the argument is an instance of Date, the function returns its clone.
         /// If the argument is a number, it is treated as a timestamp.
         /// If an argument is a string, the function tries to parse it. Function accepts complete ISO 8601 formats as well as partial implementations. ISO 8601: http://en.wikipedia.org/wiki/ISO_8601
         /// If all above fails, the function passes the given argument to Date constructor.
-        static member Parse(date: int, opts: ParseOpts) : DateTime = ExternalDateFns.parseWithOpts date opts
-        
+        static member inline Parse(date: int, opts: ParseOpts) : DateTime = ExternalDateFns.parseWithOpts date opts

--- a/src/DateFns.fs
+++ b/src/DateFns.fs
@@ -9,21 +9,21 @@ type ILocale = interface end
 type ParialMethod = Floor | Ceiling | Round
 
 [<StringEnum>]
-type TimeUnit = 
-    | [<CompiledName("s")>] Second 
-    | [<CompiledName("m")>] Minute 
-    | [<CompiledName("h")>] Hour 
-    | [<CompiledName("d")>] Day 
-    | [<CompiledName("M")>] Month 
+type TimeUnit =
+    | [<CompiledName("s")>] Second
+    | [<CompiledName("m")>] Minute
+    | [<CompiledName("h")>] Hour
+    | [<CompiledName("d")>] Day
+    | [<CompiledName("M")>] Month
     | [<CompiledName("Y")>] Year
 
-type Months = 
+type Months =
     | January = 0
     | Februari = 1
     | March = 2
     | April = 3
     | May = 4
-    | June = 5 
+    | June = 5
     | July = 6
     | August = 7
     | September = 8
@@ -31,7 +31,7 @@ type Months =
     | November = 10
     | December = 11
 
-type IDistanceInWordsOptions = 
+type IDistanceInWordsOptions =
     /// distances less than a minute are more detailed
     abstract includeSeconds : bool with get, set
     /// result indicates if the second date is earlier or later than the first
@@ -39,7 +39,7 @@ type IDistanceInWordsOptions =
     /// the locale object
     abstract locale : ILocale with get, set
 
-type IDistanceInWordsStrictOptions = 
+type IDistanceInWordsStrictOptions =
     /// Result indicates if the second date is earlier or later than the first
     abstract addSuffix : bool with get, set
     /// if specified, will force a unit
@@ -49,15 +49,15 @@ type IDistanceInWordsStrictOptions =
     /// the locale object
     abstract locale : ILocale with get, set
 
-type IDateFormatOptions = 
+type IDateFormatOptions =
     /// the locale object
     abstract locale : ILocale with get, set
 
-type ParseOpts = 
+type ParseOpts =
     /// the additional number of digits in the extended year format.
     abstract additionalDigits : int with get, set
 
-module internal ExternalDateFns = 
+module ExternalDateFns =
     let closestIndexTo (d: obj) (other: obj) = importDefault "date-fns/closest_index_to"
     let closestTo (date: obj) (other : obj) = importDefault "date-fns/closest_to"
     let compareAsc (date: obj) (other: obj) = importDefault "date-fns/compare_asc"

--- a/src/DayHelpers.fs
+++ b/src/DayHelpers.fs
@@ -3,34 +3,34 @@ namespace Fable.DateFunctions
 open System
 
 [<AutoOpen>]
-module DayHelpers =    
+module DayHelpers =
     type DateTime with
         /// Add the specified number of days to the given date.
-        member date.AddDays(days: int) : DateTime = ExternalDateFns.addDays date days
+        member inline date.AddDays(days: int) : DateTime = ExternalDateFns.addDays date days
         /// Get the number of calendar days between the given dates.
-        member dateLeft.DifferenceInCalenderDays(dateRight: DateTime) : int = ExternalDateFns.differenceInCalendarDays dateLeft dateRight
+        member inline dateLeft.DifferenceInCalenderDays(dateRight: DateTime) : int = ExternalDateFns.differenceInCalendarDays dateLeft dateRight
         /// Get the number of full days between the given dates.
-        member dateLeft.DifferenceInDays(dateRight: DateTime) : int = ExternalDateFns.differenceInDays dateLeft dateRight
+        member inline dateLeft.DifferenceInDays(dateRight: DateTime) : int = ExternalDateFns.differenceInDays dateLeft dateRight
         /// Return the array of dates within the specified range.
-        static member DatesBetween(startDate : DateTime, endDate: DateTime) : DateTime[] = ExternalDateFns.eachDay startDate endDate
+        static member inline DatesBetween(startDate : DateTime, endDate: DateTime) : DateTime[] = ExternalDateFns.eachDay startDate endDate
         /// Return the end of a day for the given date. The result will be in the local timezone.
-        member date.EndOfDay() : DateTime = ExternalDateFns.endOfDay date
-        static member EndOfToday() : DateTime = ExternalDateFns.endOfToday()
-        static member EndOfTomorrow() : DateTime = ExternalDateFns.endOfTomorrow()
-        static member EndOfYesterday() : DateTime = ExternalDateFns.endOfYesterday()
-        member date.GetDayOfMonth() : int = ExternalDateFns.getDate date
-        member date.GetDayOfYear() : int = ExternalDateFns.getDayOfYear date
+        member inline date.EndOfDay() : DateTime = ExternalDateFns.endOfDay date
+        static member inline EndOfToday() : DateTime = ExternalDateFns.endOfToday()
+        static member inline EndOfTomorrow() : DateTime = ExternalDateFns.endOfTomorrow()
+        static member inline EndOfYesterday() : DateTime = ExternalDateFns.endOfYesterday()
+        member inline date.GetDayOfMonth() : int = ExternalDateFns.getDate date
+        member inline date.GetDayOfYear() : int = ExternalDateFns.getDayOfYear date
         /// Returns whether or not the given dates are in the same day
-        member date.IsInTheSameDayAs(otherDate: DateTime) : bool = ExternalDateFns.isSameDay date otherDate
+        member inline date.IsInTheSameDayAs(otherDate: DateTime) : bool = ExternalDateFns.isSameDay date otherDate
         /// Returns whether or not the given date is today.
-        member date.IsToday() : bool = ExternalDateFns.isToday date
-        member date.IsTomorrow() : bool = ExternalDateFns.isTomorrow date
-        member date.IsYesterday() : bool = ExternalDateFns.isYesterday date
-        member date.SetDayOfMonth(dayOfMonth: int) : DateTime = ExternalDateFns.setDate date dayOfMonth
-        member date.SetDayOfYear(day: int) : DateTime = ExternalDateFns.setDayOfyear date day
+        member inline date.IsToday() : bool = ExternalDateFns.isToday date
+        member inline date.IsTomorrow() : bool = ExternalDateFns.isTomorrow date
+        member inline date.IsYesterday() : bool = ExternalDateFns.isYesterday date
+        member inline date.SetDayOfMonth(dayOfMonth: int) : DateTime = ExternalDateFns.setDate date dayOfMonth
+        member inline date.SetDayOfYear(day: int) : DateTime = ExternalDateFns.setDayOfyear date day
         /// Returns that start of the day of the given date
-        member date.StartOfDay() : DateTime = ExternalDateFns.startOfDay date
-        static member StartOfToday() : DateTime = ExternalDateFns.startOfToday()
-        static member StartOfYesterday() : DateTime = ExternalDateFns.startOfYesterday()
-        static member StartOfTomorrow() : DateTime = ExternalDateFns.startOfTomorrow()
-        member date.SubtractDays(days: int) : DateTime = ExternalDateFns.subDays date days
+        member inline date.StartOfDay() : DateTime = ExternalDateFns.startOfDay date
+        static member inline StartOfToday() : DateTime = ExternalDateFns.startOfToday()
+        static member inline StartOfYesterday() : DateTime = ExternalDateFns.startOfYesterday()
+        static member inline StartOfTomorrow() : DateTime = ExternalDateFns.startOfTomorrow()
+        member inline date.SubtractDays(days: int) : DateTime = ExternalDateFns.subDays date days

--- a/src/HourHelpers.fs
+++ b/src/HourHelpers.fs
@@ -3,21 +3,21 @@ namespace Fable.DateFunctions
 open System
 
 [<AutoOpen>]
-module HourHelpers = 
-    type DateTime with 
+module HourHelpers =
+    type DateTime with
         /// Adds the specified number of hours to the given date, returns a new date.
-        member date.AddHours(amount : int) : DateTime = ExternalDateFns.addHours date amount
+        member inline date.AddHours(amount : int) : DateTime = ExternalDateFns.addHours date amount
         /// Get the number of hours between the given dates.
-        member date.DifferenceInHours(otherDate: DateTime) : int = ExternalDateFns.differenceInHours date otherDate
+        member inline date.DifferenceInHours(otherDate: DateTime) : int = ExternalDateFns.differenceInHours date otherDate
         /// Return the end of an hour for the given date. The result will be in the local timezone.
-        member date.EndOfHour() : DateTime = ExternalDateFns.endOfHour date
+        member inline date.EndOfHour() : DateTime = ExternalDateFns.endOfHour date
         /// Are the given dates in the same hour?
-        member date.IsTheSameHourAs(otherDate : DateTime) : bool = ExternalDateFns.isSameHour date otherDate
+        member inline date.IsTheSameHourAs(otherDate : DateTime) : bool = ExternalDateFns.isSameHour date otherDate
         /// Is the given date in the same hour as the current date?
-        member date.IsInThisHour() : bool = ExternalDateFns.isThisHour date
+        member inline date.IsInThisHour() : bool = ExternalDateFns.isThisHour date
         /// Set the hours to the given date.
-        member date.SetHours(hours: int) : DateTime = ExternalDateFns.setHours date hours
+        member inline date.SetHours(hours: int) : DateTime = ExternalDateFns.setHours date hours
         /// Return the start of an hour for the given date. The result will be in the local timezone.
-        member date.StartOfHour() : DateTime = ExternalDateFns.startOfHour date
+        member inline date.StartOfHour() : DateTime = ExternalDateFns.startOfHour date
         /// Subtract the specified number of hours from the given date.
-        member date.SubtractHours(hours: int) : DateTime = ExternalDateFns.subHours date hours
+        member inline date.SubtractHours(hours: int) : DateTime = ExternalDateFns.subHours date hours

--- a/src/IsoWeeksHelper.fs
+++ b/src/IsoWeeksHelper.fs
@@ -1,18 +1,18 @@
-namespace Fable.DateFunctions 
+namespace Fable.DateFunctions
 
-open System 
+open System
 
 [<AutoOpen>]
-module IsoWeeksHelper = 
-    type DateTime with 
+module IsoWeeksHelper =
+    type DateTime with
         /// Get the number of calendar ISO weeks between the given dates.
-        member date.DifferenceInCalendarISOWeeks(otherDate: DateTime) : int = ExternalDateFns.differenceInCalendarISOWeeks date otherDate
+        member inline date.DifferenceInCalendarISOWeeks(otherDate: DateTime) : int = ExternalDateFns.differenceInCalendarISOWeeks date otherDate
         /// Return the end of an ISO week for the given date. The result will be in the local timezone.
-        member date.EndOfIsoWeek() : DateTime = ExternalDateFns.endOfIsoWeek date
-        member date.IsInTheSameISOWeekAs(otherDate: DateTime) : bool = ExternalDateFns.isSameIsoWeek date otherDate
-        member date.IsInThisISOWeek() : bool = ExternalDateFns.isThisIsoWeek date 
-        member date.GetISOWeek() : int = ExternalDateFns.getISOWeek date
-        member date.LastDayOfISOWeek() : DateTime = ExternalDateFns.lastDayOfIsoWeek date 
-        member date.StartOfISOWeek() : DateTime = ExternalDateFns.startOfIsoWeek date
+        member inline date.EndOfIsoWeek() : DateTime = ExternalDateFns.endOfIsoWeek date
+        member inline date.IsInTheSameISOWeekAs(otherDate: DateTime) : bool = ExternalDateFns.isSameIsoWeek date otherDate
+        member inline date.IsInThisISOWeek() : bool = ExternalDateFns.isThisIsoWeek date
+        member inline date.GetISOWeek() : int = ExternalDateFns.getISOWeek date
+        member inline date.LastDayOfISOWeek() : DateTime = ExternalDateFns.lastDayOfIsoWeek date
+        member inline date.StartOfISOWeek() : DateTime = ExternalDateFns.startOfIsoWeek date
         /// Set the ISO week to the given date, saving the weekday number.
-        member date.SetISOWeek(n : int) : DateTime = ExternalDateFns.setIsoWeek date n
+        member inline date.SetISOWeek(n : int) : DateTime = ExternalDateFns.setIsoWeek date n

--- a/src/Locales.fs
+++ b/src/Locales.fs
@@ -1,41 +1,41 @@
 namespace Fable.DateFunctions
 
 open Fable.Core.JsInterop
-open System 
+open System
 
-type DateFnLocales() = 
-    member this.Russian : ILocale = importDefault "date-fns/locale/ru"
-    member this.French : ILocale = importDefault "date-fns/locale/fr"
-    member this.Esperanto : ILocale = importDefault "date-fns/locale/eo"
-    member this.ChineseSimplified : ILocale = importDefault "date-fns/locale/zh_cn"
-    member this.German : ILocale = importDefault "date-fns/locale/de"
-    member this.Spanish : ILocale = importDefault "date-fns/locale/es"
-    member this.Japanese : ILocale = importDefault "date-fns/locale/ja"
-    member this.Dutch : ILocale = importDefault "date-fns/locale/nl"
-    member this.ChineseTraditional : ILocale = importDefault "date-fns/locale/zh_tw"
-    member this.NorwegianBokmal : ILocale = importDefault "date-fns/locale/nb" 
-    member this.Indonesian : ILocale = importDefault "date-fns/locale/nb"
-    member this.Italian : ILocale = importDefault "date-fns/locale/it"
-    member this.Polish : ILocale = importDefault "date-fns/locale/pl"
-    member this.Portuguese : ILocale = importDefault "date-fns/locale/pt"
-    member this.Swedish : ILocale = importDefault "date-fns/locale/sv"
-    member this.Turkish : ILocale = importDefault "date-fns/locale/tr"
-    member this.Korean : ILocale = importDefault "date-fns/locale/ko"
-    member this.Greek : ILocale = importDefault "date-fns/locale/el"
-    member this.Slovak : ILocale = importDefault "date-fns/locale/sk"
-    member this.Filipino : ILocale = importDefault "date-fns/locale/fil"
-    member this.Danish : ILocale = importDefault "date-fns/locale/da"
-    member this.IceLandic : ILocale = importDefault "date-fns/locale/is"
-    member this.Finnish : ILocale = importDefault "date-fns/locale/fi"
-    member this.Thai : ILocale = importDefault "date-fns/locale/th"
-    member this.Croatian : ILocale = importDefault "date-fns/locale/hr"
-    member this.Arabic : ILocale = importDefault "date-fns/locale/ar"
-    member this.Bulgarian : ILocale = importDefault "date-fns/locale/bg"
-    member this.Czech : ILocale = importDefault "date-fns/locale/cs"
-    member this.Macedonian : ILocale = importDefault "date-fns/locale/mk"
-    member this.Romanian : ILocale = importDefault "date-fns/locale/ro"
+type DateFnLocales() =
+    member inline this.Russian : ILocale = importDefault "date-fns/locale/ru"
+    member inline this.French : ILocale = importDefault "date-fns/locale/fr"
+    member inline this.Esperanto : ILocale = importDefault "date-fns/locale/eo"
+    member inline this.ChineseSimplified : ILocale = importDefault "date-fns/locale/zh_cn"
+    member inline this.German : ILocale = importDefault "date-fns/locale/de"
+    member inline this.Spanish : ILocale = importDefault "date-fns/locale/es"
+    member inline this.Japanese : ILocale = importDefault "date-fns/locale/ja"
+    member inline this.Dutch : ILocale = importDefault "date-fns/locale/nl"
+    member inline this.ChineseTraditional : ILocale = importDefault "date-fns/locale/zh_tw"
+    member inline this.NorwegianBokmal : ILocale = importDefault "date-fns/locale/nb"
+    member inline this.Indonesian : ILocale = importDefault "date-fns/locale/nb"
+    member inline this.Italian : ILocale = importDefault "date-fns/locale/it"
+    member inline this.Polish : ILocale = importDefault "date-fns/locale/pl"
+    member inline this.Portuguese : ILocale = importDefault "date-fns/locale/pt"
+    member inline this.Swedish : ILocale = importDefault "date-fns/locale/sv"
+    member inline this.Turkish : ILocale = importDefault "date-fns/locale/tr"
+    member inline this.Korean : ILocale = importDefault "date-fns/locale/ko"
+    member inline this.Greek : ILocale = importDefault "date-fns/locale/el"
+    member inline this.Slovak : ILocale = importDefault "date-fns/locale/sk"
+    member inline this.Filipino : ILocale = importDefault "date-fns/locale/fil"
+    member inline this.Danish : ILocale = importDefault "date-fns/locale/da"
+    member inline this.IceLandic : ILocale = importDefault "date-fns/locale/is"
+    member inline this.Finnish : ILocale = importDefault "date-fns/locale/fi"
+    member inline this.Thai : ILocale = importDefault "date-fns/locale/th"
+    member inline this.Croatian : ILocale = importDefault "date-fns/locale/hr"
+    member inline this.Arabic : ILocale = importDefault "date-fns/locale/ar"
+    member inline this.Bulgarian : ILocale = importDefault "date-fns/locale/bg"
+    member inline this.Czech : ILocale = importDefault "date-fns/locale/cs"
+    member inline this.Macedonian : ILocale = importDefault "date-fns/locale/mk"
+    member inline this.Romanian : ILocale = importDefault "date-fns/locale/ro"
 
 [<AutoOpen>]
-module LocalesHelper = 
-    type DateTime with 
-        static member Locales = DateFnLocales()
+module LocalesHelper =
+    type DateTime with
+        static member inline Locales = DateFnLocales()

--- a/src/MillisecondHelpers.fs
+++ b/src/MillisecondHelpers.fs
@@ -6,15 +6,15 @@ open Fable.Core.JsInterop
 open Fable.Import
 
 [<AutoOpen>]
-module MillisecondHelpers = 
+module MillisecondHelpers =
     type DateTime with
         /// Adds the given amount of milliseconds to the given time and returns a new DateTime instance.
-        member date.AddMilliseconds(amount: int) : DateTime = ExternalDateFns.addMilliseconds date amount
+        member inline date.AddMilliseconds(amount: int) : DateTime = ExternalDateFns.addMilliseconds date amount
         /// Get the number of milliseconds between the given dates.
-        member date.DifferenceInMilliseconds(otherDate: DateTime) : int = ExternalDateFns.differenceInMilliseconds date otherDate
+        member inline date.DifferenceInMilliseconds(otherDate: DateTime) : int = ExternalDateFns.differenceInMilliseconds date otherDate
         /// Get the milliseconds of the given date.
-        member date.GetMilliseconds() : int = ExternalDateFns.getMilliseconds date
+        member inline date.GetMilliseconds() : int = ExternalDateFns.getMilliseconds date
         /// Set the milliseconds to the given date, returns a new date with the milliseconds setted.
-        member date.SetMilliseconds(ms: int) : DateTime = ExternalDateFns.setMilliseconds date ms
+        member inline date.SetMilliseconds(ms: int) : DateTime = ExternalDateFns.setMilliseconds date ms
         /// Subtract the specified number of milliseconds from the given date, returns a new DateTime instance.
-        member date.SubtractMilliseconds(ms: int) : DateTime = ExternalDateFns.subMilliseconds date ms
+        member inline date.SubtractMilliseconds(ms: int) : DateTime = ExternalDateFns.subMilliseconds date ms

--- a/src/MinuteHelpers.fs
+++ b/src/MinuteHelpers.fs
@@ -6,23 +6,23 @@ open Fable.Core.JsInterop
 open Fable.Import
 
 [<AutoOpen>]
-module MinuteHelpers = 
+module MinuteHelpers =
     type DateTime with
         /// Adds the specified number of minutes to the given date and returns a new Date.
-        member date.AddMinutes(amount: int) : DateTime = ExternalDateFns.addMinutes date amount
+        member inline date.AddMinutes(amount: int) : DateTime = ExternalDateFns.addMinutes date amount
         /// Get the number of minutes between the given dates.
-        member date.DifferenceInMinutes(otherDate : DateTime) : int = ExternalDateFns.differenceInMinutes date otherDate
+        member inline date.DifferenceInMinutes(otherDate : DateTime) : int = ExternalDateFns.differenceInMinutes date otherDate
         /// Return the end of a minute for the given date. The result will be in the local timezone.
-        member date.EndOfMinute() : DateTime = ExternalDateFns.endOfMinute date
+        member inline date.EndOfMinute() : DateTime = ExternalDateFns.endOfMinute date
         /// Returns the minutes of the given date.
-        member date.GetMinutes() : int = ExternalDateFns.getMinutes date
+        member inline date.GetMinutes() : int = ExternalDateFns.getMinutes date
         /// Returns whether or not the given dates are in the same minute
-        member date.IsInSameMinuteAs(otherDate : DateTime) : bool = ExternalDateFns.isSameMinute date otherDate
+        member inline date.IsInSameMinuteAs(otherDate : DateTime) : bool = ExternalDateFns.isSameMinute date otherDate
         /// Returns whether or not the given date is in this minute of the current date.
-        member date.IsInThisMinute() : bool = ExternalDateFns.isThisMinute date
+        member inline date.IsInThisMinute() : bool = ExternalDateFns.isThisMinute date
         /// Sets the minutes to the given date and returns a new DateTime
-        member date.SetMinutes(minutes: int) : DateTime = ExternalDateFns.setMinutes date minutes
+        member inline date.SetMinutes(minutes: int) : DateTime = ExternalDateFns.setMinutes date minutes
         /// Return the start of a minute for the given date. The result will be in the local timezone.
-        member date.StartOfMinute() : DateTime = ExternalDateFns.startOfMinute date
+        member inline date.StartOfMinute() : DateTime = ExternalDateFns.startOfMinute date
         /// Subtracts the specified number of minutes from the given date and returns a new date.
-        member date.SubtractMinutes(minutes : int) : DateTime = ExternalDateFns.subMinutes date minutes
+        member inline date.SubtractMinutes(minutes : int) : DateTime = ExternalDateFns.subMinutes date minutes

--- a/src/MonthHelpers.fs
+++ b/src/MonthHelpers.fs
@@ -1,19 +1,19 @@
 namespace Fable.DateFunctions
 
-open System 
+open System
 
 [<AutoOpen>]
-module MonthHelpers = 
-    type DateTime with 
-        member date.AddMonths(months: int) : DateTime = ExternalDateFns.addMonths date months
-        member date.DifferenceInCalendarMonths(otherDate : DateTime) : int = ExternalDateFns.differenceInCalendarMonths date otherDate 
-        member date.DifferenceInMonths(otherDate : DateTime) : int = ExternalDateFns.differenceInMonths date otherDate 
-        member date.EndOfMonth() : DateTime = ExternalDateFns.endOfMonth date
-        member date.GetDaysInMonth() : int = ExternalDateFns.getDaysInMonth date
-        member date.IsFirstDayOfMonth() : bool = ExternalDateFns.isFirstDayOfMonth date 
-        member date.IsLastDayOfMonth() : bool = ExternalDateFns.isLastDayOfMonth date
-        member date.IsInTheSameMonthAs(otherDate: DateTime) : bool = ExternalDateFns.isSameMonth date otherDate
-        member date.IsInThisMonth() : bool = ExternalDateFns.isThisMonth date
-        member date.SetMonth(month : Months) : DateTime = ExternalDateFns.setMonth date month
-        member date.StartOfMonth() : DateTime = ExternalDateFns.startOfMonth date 
-        member date.SubtractMonths(months: int) : DateTime = ExternalDateFns.subMonths date months
+module MonthHelpers =
+    type DateTime with
+        member inline date.AddMonths(months: int) : DateTime = ExternalDateFns.addMonths date months
+        member inline date.DifferenceInCalendarMonths(otherDate : DateTime) : int = ExternalDateFns.differenceInCalendarMonths date otherDate
+        member inline date.DifferenceInMonths(otherDate : DateTime) : int = ExternalDateFns.differenceInMonths date otherDate
+        member inline date.EndOfMonth() : DateTime = ExternalDateFns.endOfMonth date
+        member inline date.GetDaysInMonth() : int = ExternalDateFns.getDaysInMonth date
+        member inline date.IsFirstDayOfMonth() : bool = ExternalDateFns.isFirstDayOfMonth date
+        member inline date.IsLastDayOfMonth() : bool = ExternalDateFns.isLastDayOfMonth date
+        member inline date.IsInTheSameMonthAs(otherDate: DateTime) : bool = ExternalDateFns.isSameMonth date otherDate
+        member inline date.IsInThisMonth() : bool = ExternalDateFns.isThisMonth date
+        member inline date.SetMonth(month : Months) : DateTime = ExternalDateFns.setMonth date month
+        member inline date.StartOfMonth() : DateTime = ExternalDateFns.startOfMonth date
+        member inline date.SubtractMonths(months: int) : DateTime = ExternalDateFns.subMonths date months

--- a/src/RangeHelpers.fs
+++ b/src/RangeHelpers.fs
@@ -6,8 +6,8 @@ open System
 module RangeHelpers =
     type DateTime with
         /// Returns whether or not the given ranges overlap
-        static member AreRangesOverlapping(initRangeStartDate: DateTime, initRangeEndDate: DateTime, comparedRangeStart: DateTime, comparedRangeEnd: DateTime) : bool = ExternalDateFns.areRangesOverlapping initRangeStartDate initRangeEndDate comparedRangeStart comparedRangeEnd
+        static member inline AreRangesOverlapping(initRangeStartDate: DateTime, initRangeEndDate: DateTime, comparedRangeStart: DateTime, comparedRangeEnd: DateTime) : bool = ExternalDateFns.areRangesOverlapping initRangeStartDate initRangeEndDate comparedRangeStart comparedRangeEnd
         /// Returns the number of days that overlap in two date ranges
-        static member GetOverlappingDaysInRanges(initRangeStartDate: DateTime, initRangeEndDate: DateTime, comparedRangeStart: DateTime, comparedRangeEnd: DateTime) : int = ExternalDateFns.getOverlappingDaysInRanges initRangeStartDate initRangeEndDate comparedRangeStart comparedRangeEnd
+        static member inline GetOverlappingDaysInRanges(initRangeStartDate: DateTime, initRangeEndDate: DateTime, comparedRangeStart: DateTime, comparedRangeEnd: DateTime) : int = ExternalDateFns.getOverlappingDaysInRanges initRangeStartDate initRangeEndDate comparedRangeStart comparedRangeEnd
         /// Returns whether the first argument is within the range of the second and third argument.
-        member date.IsBetween(startDate: DateTime, endDate: DateTime) : bool = ExternalDateFns.isWithinRange date startDate endDate       
+        member inline date.IsBetween(startDate: DateTime, endDate: DateTime) : bool = ExternalDateFns.isWithinRange date startDate endDate

--- a/src/SecondHelpers.fs
+++ b/src/SecondHelpers.fs
@@ -3,23 +3,23 @@ namespace Fable.DateFunctions
 open System
 
 [<AutoOpen>]
-module SecondHelpers = 
+module SecondHelpers =
     type DateTime with
         /// Add the specified number of seconds to the given date and returns a new date.
-        member date.AddSeconds(amount: int) : DateTime = ExternalDateFns.addSeconds date amount
+        member inline date.AddSeconds(amount: int) : DateTime = ExternalDateFns.addSeconds date amount
         /// Returns the number of seconds between the given dates.
-        member date.DifferenceInSeconds(other: DateTime) : int = ExternalDateFns.differenceInSeconds date other
+        member inline date.DifferenceInSeconds(other: DateTime) : int = ExternalDateFns.differenceInSeconds date other
         /// Returns the end of a second for the given date. The result will be in the local timezone.
-        member date.EndOfSecond() : DateTime = ExternalDateFns.endOfSecond date
+        member inline date.EndOfSecond() : DateTime = ExternalDateFns.endOfSecond date
         /// Returns the seconds of the given date.
-        member date.GetSeconds() : int = ExternalDateFns.getSeconds date
+        member inline date.GetSeconds() : int = ExternalDateFns.getSeconds date
         /// Returns whether the given dates are in the same second.
-        member date.IsInTheSameSecondAs(other: DateTime) : bool = ExternalDateFns.isSameSecond date other
+        member inline date.IsInTheSameSecondAs(other: DateTime) : bool = ExternalDateFns.isSameSecond date other
         /// Returns whether the given date is in the same second as the current date
-        member date.IsInThisSecond() : bool = ExternalDateFns.isThisSecond date
+        member inline date.IsInThisSecond() : bool = ExternalDateFns.isThisSecond date
         /// Sets the seconds to the given date.
-        member date.SetSeconds(amount: int) : DateTime = ExternalDateFns.setSeconds date amount
+        member inline date.SetSeconds(amount: int) : DateTime = ExternalDateFns.setSeconds date amount
         /// Returns the start of a second for the given date. The result will be in the local timezone.
-        member date.StartOfSecond() : DateTime = ExternalDateFns.startOfSecond date
+        member inline date.StartOfSecond() : DateTime = ExternalDateFns.startOfSecond date
         /// Subtracts the specified number of seconds from the given date and return a new DateTime.
-        member date.SubtractSeconds(amount : int) : DateTime = ExternalDateFns.subSeconds date amount
+        member inline date.SubtractSeconds(amount : int) : DateTime = ExternalDateFns.subSeconds date amount

--- a/src/TimestampHelpers.fs
+++ b/src/TimestampHelpers.fs
@@ -3,7 +3,7 @@ namespace Fable.DateFunctions
 open System
 
 [<AutoOpen>]
-module TimestampHelpers = 
-    type DateTime with 
+module TimestampHelpers =
+    type DateTime with
         /// Returns the milliseconds timestamp of the given date.
-        member date.GetMilliseconds() : int = ExternalDateFns.getTime date
+        member inline date.GetMilliseconds() : int = ExternalDateFns.getTime date

--- a/src/WeekHelpers.fs
+++ b/src/WeekHelpers.fs
@@ -1,23 +1,23 @@
 namespace Fable.DateFunctions
 
-open System 
+open System
 
 [<AutoOpen>]
-module WeekHelpers = 
-    type DateTime with 
+module WeekHelpers =
+    type DateTime with
         /// Add the specified number of week to the given date.
-        member date.AddWeeks(numberOfWeeks: int) = ExternalDateFns.addWeeks date numberOfWeeks
+        member inline date.AddWeeks(numberOfWeeks: int) = ExternalDateFns.addWeeks date numberOfWeeks
         /// Gets the number of calendar weeks between the given dates.
-        member date.DifferenceInCalendarWeeks(otherDate: DateTime) : int = ExternalDateFns.differenceInCalendarWeeks date otherDate
+        member inline date.DifferenceInCalendarWeeks(otherDate: DateTime) : int = ExternalDateFns.differenceInCalendarWeeks date otherDate
         /// Get the number of full weeks between the given dates.
-        member date.DifferenceInWeeks(otherDate: DateTime) : int = ExternalDateFns.differenceInWeeks date otherDate
+        member inline date.DifferenceInWeeks(otherDate: DateTime) : int = ExternalDateFns.differenceInWeeks date otherDate
         /// Return the end of a week for the given date. The result will be in the local timezone.
-        member date.EndOfWeek() : DateTime = ExternalDateFns.endOfWeek date
-        member date.IsInTheSameWeekAs(otherDate: DateTime) : bool = ExternalDateFns.isSameWeek date otherDate
-        member date.IsInThisWeek() : bool = ExternalDateFns.isThisWeek date 
+        member inline date.EndOfWeek() : DateTime = ExternalDateFns.endOfWeek date
+        member inline date.IsInTheSameWeekAs(otherDate: DateTime) : bool = ExternalDateFns.isSameWeek date otherDate
+        member inline date.IsInThisWeek() : bool = ExternalDateFns.isThisWeek date
         /// Returns the DateTime of the last day of the week of the current instance of DateTime
-        member date.LastDayOfWeek() : DateTime = ExternalDateFns.lastDayOfWeek date 
+        member inline date.LastDayOfWeek() : DateTime = ExternalDateFns.lastDayOfWeek date
         /// Returns the DateTime of the first day of the week of the current instance of DateTime
-        member date.StartOfWeek() : DateTime = ExternalDateFns.startOfWeek date
-        member date.SubtractWeeks(n : int) : DateTime = ExternalDateFns.subWeeks date n
+        member inline date.StartOfWeek() : DateTime = ExternalDateFns.startOfWeek date
+        member inline date.SubtractWeeks(n : int) : DateTime = ExternalDateFns.subWeeks date n
 

--- a/src/WeekdayHelpers.fs
+++ b/src/WeekdayHelpers.fs
@@ -3,18 +3,18 @@ namespace Fable.DateFunctions
 open System
 
 [<AutoOpenAttribute>]
-module WeekdayHelpers = 
+module WeekdayHelpers =
     type DateTime with
         /// Get the day of the week of the given date.
-        member date.GetDayNumberOfWeek() : int = ExternalDateFns.getDay date
+        member inline date.GetDayNumberOfWeek() : int = ExternalDateFns.getDay date
         /// Get the day of the ISO week of the given date, which is 7 for Sunday, 1 for Monday etc.
         /// ISO week-numbering year: http://en.wikipedia.org/wiki/ISO_week_date
-        member date.GetISODayNumberOfWeek() : int = ExternalDateFns.getISODay date
-        member date.IsFriday() : bool = ExternalDateFns.isFriday date
-        member date.IsMonday() : bool = ExternalDateFns.isMonday date
-        member date.IsSaturday() : bool = ExternalDateFns.isSaturday date
-        member date.IsSunday() : bool = ExternalDateFns.isSunday date
-        member date.IsThursday() : bool = ExternalDateFns.isThursday date
-        member date.IsTuesday() : bool = ExternalDateFns.isTuesday date
-        member date.IsWednesday() : bool = ExternalDateFns.isWednesday date
-        member date.IsWeekend () : bool = ExternalDateFns.isWeekend date
+        member inline date.GetISODayNumberOfWeek() : int = ExternalDateFns.getISODay date
+        member inline date.IsFriday() : bool = ExternalDateFns.isFriday date
+        member inline date.IsMonday() : bool = ExternalDateFns.isMonday date
+        member inline date.IsSaturday() : bool = ExternalDateFns.isSaturday date
+        member inline date.IsSunday() : bool = ExternalDateFns.isSunday date
+        member inline date.IsThursday() : bool = ExternalDateFns.isThursday date
+        member inline date.IsTuesday() : bool = ExternalDateFns.isTuesday date
+        member inline date.IsWednesday() : bool = ExternalDateFns.isWednesday date
+        member inline date.IsWeekend () : bool = ExternalDateFns.isWeekend date

--- a/src/YearHelpers.fs
+++ b/src/YearHelpers.fs
@@ -1,24 +1,24 @@
 namespace Fable.DateFunctions
 
-open System 
+open System
 
 [<AutoOpen>]
-module YearHelpers = 
-    type DateTime with 
-        member date.AddYears(n: int) : DateTime = ExternalDateFns.addYears date n 
-        member date.DifferenceInCalendarYears(otherDate: DateTime) : int = ExternalDateFns.differenceInCalendarYears date otherDate 
-        member date.DifferenceInYears(otherDate: DateTime) : int = ExternalDateFns.differenceInYears date otherDate
-        member date.EndOfYear() : DateTime = ExternalDateFns.endOfYear date 
+module YearHelpers =
+    type DateTime with
+        member inline date.AddYears(n: int) : DateTime = ExternalDateFns.addYears date n
+        member inline date.DifferenceInCalendarYears(otherDate: DateTime) : int = ExternalDateFns.differenceInCalendarYears date otherDate
+        member inline date.DifferenceInYears(otherDate: DateTime) : int = ExternalDateFns.differenceInYears date otherDate
+        member inline date.EndOfYear() : DateTime = ExternalDateFns.endOfYear date
         /// Returns the number of days in the year of the current instance of DateTime
-        member date.DaysInYear() : int = ExternalDateFns.daysInYear date 
+        member inline date.DaysInYear() : int = ExternalDateFns.daysInYear date
         /// Returns whether or not the current instance of DateTime is a leap year
-        member date.IsLeapYear() : bool = ExternalDateFns.isLeapYear date
+        member inline date.IsLeapYear() : bool = ExternalDateFns.isLeapYear date
         /// Returns whether or not the given date is in the same year as the current instance of DateTime
-        member date.IsInTheSameYearAs(otherDate: DateTime) = ExternalDateFns.isSameYear date otherDate
+        member inline date.IsInTheSameYearAs(otherDate: DateTime) = ExternalDateFns.isSameYear date otherDate
         /// Returns whether or not the current instance of DateTime is in this year or not
-        member date.IsInThisYear() : bool = ExternalDateFns.isThisYear date
+        member inline date.IsInThisYear() : bool = ExternalDateFns.isThisYear date
         /// Returns the DateTime of the last day in the year of the current instance of DateTime
-        member date.LastDayOfYear() : DateTime = ExternalDateFns.lastDayOfYear date
+        member inline date.LastDayOfYear() : DateTime = ExternalDateFns.lastDayOfYear date
         /// Returns the DateTime of the first day in the year of the current instance of DateTime
-        member date.StartOfYear() : DateTime = ExternalDateFns.startOfYear date
-        member date.SubtractYears(n : int) : DateTime = ExternalDateFns.subYears date n
+        member inline date.StartOfYear() : DateTime = ExternalDateFns.startOfYear date
+        member inline date.SubtractYears(n : int) : DateTime = ExternalDateFns.subYears date n


### PR DESCRIPTION
In order to use `member inline`, I needed to remove the `inline` module [here](https://github.com/Zaid-Ajaj/Fable.DateFunctions/compare/master...MangelMaxime:use_inline?expand=1#diff-962fdab914e037d680544e8ab2db2fd2L60)