### PR TITLE
Added explicit return type to all locales

### DIFF
--- a/src/Locales.fs
+++ b/src/Locales.fs
@@ -6,7 +6,7 @@ open System
 [<Erase>]
 type DateFnLocales() =
     [<Import("az", "date-fns/locale")>]
-    member inline this.Azerbaijani = jsNative
+    member inline this.Azerbaijani : ILocale = jsNative
     [<Import("ru", "date-fns/locale")>]
     member inline this.Russian : ILocale = jsNative
     [<Import("fr", "date-fns/locale")>]
@@ -83,7 +83,7 @@ type DateFnLocales() =
     [<Import("faIR", "date-fns/locale")>]
     member inline this.Persian : ILocale = jsNative
     [<Import("sl", "date-fns/locale")>]
-    member inline this.Slovenian = jsNative
+    member inline this.Slovenian : ILocale = jsNative
 
 [<AutoOpen>]
 module LocalesHelper =


### PR DESCRIPTION
Added explicit return type (ILocale) to all DateFnLocales.
In my previous PR I copy/pasted the first language which didn't had the return type explicitly set.
This fixes it.
