### PR TITLE
add EnglishGB locale

### DIFF
--- a/src/Locales.fs
+++ b/src/Locales.fs
@@ -84,6 +84,9 @@ type DateFnLocales() =
     member inline this.Persian : ILocale = jsNative
     [<Import("sl", "date-fns/locale")>]
     member inline this.Slovenian : ILocale = jsNative
+    [<Import("enGB", "date-fns/locale")>]
+    member inline this.EnglishGB : ILocale = jsNative
+    
 
 [<AutoOpen>]
 module LocalesHelper =


### PR DESCRIPTION
Hello Zaid, I added EnglishGB locale as there is no English locale present. 

I'm not sure about naming since there are multiple English locales in the date-fns library so if you have any opinion on this I will change the name so that it is in line with your intentions :)